### PR TITLE
Add image tag

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'vendor/**/*'
     - 'node_modules/**/*'
     - 'bin/*'
+    - 'db/migrate/20190807*'
   TargetRubyVersion: 2.5
 
 Layout/IndentFirstArrayElement:

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'jquery-rails'
 
 gem 'webpacker', '~> 4'
 
+gem 'acts-as-taggable-on', '~> 6.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (6.0.0)
+      activerecord (~> 5.0)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
@@ -225,6 +227,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 6.0)
   byebug
   capybara
   jquery-rails

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -22,6 +22,6 @@ class PicturesController < ApplicationController
   private
 
   def picture_params
-    params.require(:picture).permit(:name, :link)
+    params.require(:picture).permit(:name, :link, :tag_list)
   end
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,4 +1,5 @@
 class Picture < ApplicationRecord
+  acts_as_taggable_on :tags
   validates :name, presence: true
   validates :link, presence: true
   validate :validates_image_url

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -4,12 +4,14 @@
   <tr>
     <th>Name</th>
     <th>Image</th>
+    <th>Tags</th>
   </tr>
 
   <% @pictures.reverse_each do |picture| %>
     <tr>
       <td><%= picture.name %></td>
       <td><%= image_tag src = picture.link %></td>
+      <td><%= picture.tag_list %></td>
       <td><%= link_to 'Show', picture_path(picture) %></td>
     </tr>
   <% end %>

--- a/app/views/pictures/new.html.erb
+++ b/app/views/pictures/new.html.erb
@@ -14,6 +14,11 @@
   </p>
 
   <p>
+    <%= form.label :tag_list %><br>
+    <%= form.text_area :tag_list %>
+  </p>
+
+  <p>
     <%= form.submit %>
   </p>
 <% end %>

--- a/app/views/pictures/show.html.erb
+++ b/app/views/pictures/show.html.erb
@@ -6,3 +6,8 @@
 <p>
   <%= image_tag src=@picture.link %>
 </p>
+
+<p>
+  <strong>Tags:</strong>
+  <%= @picture.tag_list %>
+</p>

--- a/db/migrate/20190807204819_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204819_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,36 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]; end
+else
+  class ActsAsTaggableOnMigration < ActiveRecord::Migration; end
+end
+ActsAsTaggableOnMigration.class_eval do
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20190807204820_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204820_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,26 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingUniqueIndices < ActiveRecord::Migration; end
+end
+AddMissingUniqueIndices.class_eval do
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20190807204821_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204821_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]; end
+else
+  class AddTaggingsCounterCacheToTags < ActiveRecord::Migration; end
+end
+AddTaggingsCounterCacheToTags.class_eval do
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20190807204822_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204822_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingTaggableIndex < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingTaggableIndex < ActiveRecord::Migration; end
+end
+AddMissingTaggableIndex.class_eval do
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20190807204823_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204823_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class ChangeCollationForTagNames < ActiveRecord::Migration[4.2]; end
+else
+  class ChangeCollationForTagNames < ActiveRecord::Migration; end
+end
+ChangeCollationForTagNames.class_eval do
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20190807204824_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20190807204824_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,38 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_203555) do
+ActiveRecord::Schema.define(version: 2019_08_07_204824) do
 
   create_table "pictures", force: :cascade do |t|
     t.string "name"
     t.text "link"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context"
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context"
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy"
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id"
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type"
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type"
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
 end

--- a/test/controllers/pictures_controller_test.rb
+++ b/test/controllers/pictures_controller_test.rb
@@ -2,7 +2,9 @@ require 'test_helper'
 
 class PicturesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @picture = Picture.create!(name: 'Alice', link: 'https://robohash.org/32M.png?set=set4')
+    @picture = Picture.create!(name: 'Alice',
+                               link: 'https://robohash.org/32M.png?set=set4',
+                               tag_list: 'cat, animal')
   end
 
   def test_new
@@ -29,7 +31,7 @@ class PicturesControllerTest < ActionDispatch::IntegrationTest
 
   def test_create__succeed
     assert_difference('Picture.count', 1) do
-      picture_params = { name: 'Dog', link: 'https://robohash.org/66M.png?set=set4' }
+      picture_params = { name: 'Dog', link: 'https://robohash.org/66M.png?set=set4', tag_list: 'dog, animal' }
       post pictures_path, params: { picture: picture_params }
     end
 
@@ -38,7 +40,7 @@ class PicturesControllerTest < ActionDispatch::IntegrationTest
 
   def test_create__fail_unresolvable_url
     assert_no_difference('Picture.count') do
-      picture_params = { name: 'Google', link: 'google.com' }
+      picture_params = { name: 'Google', link: 'google.com', tag_list: 'website, company' }
       post pictures_path, params: { picture: picture_params }
     end
 
@@ -48,7 +50,7 @@ class PicturesControllerTest < ActionDispatch::IntegrationTest
 
   def test_create__fail_no_remote_image
     assert_no_difference('Picture.count') do
-      picture_params = { name: 'Google', link: 'https://www.google.com' }
+      picture_params = { name: 'Google', link: 'https://www.google.com', tag_list: 'website, company' }
       post pictures_path, params: { picture: picture_params }
     end
 


### PR DESCRIPTION
**Story**:
Our users are loving the ability to add images to our service. However, now
that there are more than a handful of images, it is apparent that we need some
way to filter images by certain categories. In order to do that, we first need
to label images in some way. It is time to add the ability for our users to tag
images when they add them.

**Acceptance criteria**:
-[x] When I add a new image, there is a form field to add tags.
-[x] After I've saved an image with tags, I see those tags displayed with the
associated image.
-[x] My application uses the acts-as-taggable-on gem to provide the tagging
functionality.

**Note**: You should allow images to have no tags; this sets the stage for a later issue.