### PR TITLE
Images by tag

### DIFF
--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -2,7 +2,11 @@ class PicturesController < ApplicationController
   def new; end
 
   def index
-    @pictures = Picture.all
+    @pictures = if params[:tag_list].empty?
+                  Picture.all
+                else
+                  Picture.tagged_with(params[:tag_list])
+                end
   end
 
   def create

--- a/app/controllers/pictures_controller.rb
+++ b/app/controllers/pictures_controller.rb
@@ -2,10 +2,10 @@ class PicturesController < ApplicationController
   def new; end
 
   def index
-    @pictures = if params[:tag_list].empty?
+    @pictures = if params[:tag].blank?
                   Picture.all
                 else
-                  Picture.tagged_with(params[:tag_list])
+                  Picture.tagged_with(params[:tag])
                 end
   end
 

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -1,8 +1,8 @@
 <h1>Image Uploaded</h1>
 
 <h4>Search by Tag</h4>
-<%= form_tag(pictures_path, method: :get) do %>
-  <%= text_field_tag :tag_list, params[:tag_list] %>
+<%= form_tag(tagged_path, method: :get) do %>
+  <%= text_field_tag :tag, params[:tag] %>
   <%= submit_tag 'Search' %>
 <% end %>
 
@@ -17,7 +17,14 @@
     <tr>
       <td><%= picture.name %></td>
       <td><%= image_tag src = picture.link %></td>
-      <td><%= picture.tag_list %></td>
+      <td>
+        <div>
+          <span class = 'js_tag'>Tags: </span>
+          <% picture.tag_list.each do |tag| %>
+            <%= link_to tag, tagged_path(tag: tag) %>
+          <% end %>
+        </div>
+      </td>
       <td><%= link_to 'Show', picture_path(picture) %></td>
     </tr>
   <% end %>

--- a/app/views/pictures/index.html.erb
+++ b/app/views/pictures/index.html.erb
@@ -1,5 +1,11 @@
 <h1>Image Uploaded</h1>
 
+<h4>Search by Tag</h4>
+<%= form_tag(pictures_path, method: :get) do %>
+  <%= text_field_tag :tag_list, params[:tag_list] %>
+  <%= submit_tag 'Search' %>
+<% end %>
+
 <table>
   <tr>
     <th>Name</th>

--- a/app/views/pictures/show.html.erb
+++ b/app/views/pictures/show.html.erb
@@ -7,7 +7,9 @@
   <%= image_tag src=@picture.link %>
 </p>
 
-<p>
-  <strong>Tags:</strong>
-  <%= @picture.tag_list %>
-</p>
+<div>
+  <span class = 'js_tag'><strong>Tags:</strong></span>
+  <% @picture.tag_list.each do |tag| %>
+    <%= link_to tag, tagged_path(tag: tag) %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'pictures#index'
   resources :pictures
+  get '/tagged', to: 'pictures#index', as: :tagged
 end

--- a/test/controllers/pictures_controller_test.rb
+++ b/test/controllers/pictures_controller_test.rb
@@ -4,7 +4,7 @@ class PicturesControllerTest < ActionDispatch::IntegrationTest
   setup do
     @picture = Picture.create!(name: 'Alice',
                                link: 'https://robohash.org/32M.png?set=set4',
-                               tag_list: 'cat, animal')
+                               tag_list: 'cat, animal, existing_tag')
   end
 
   def test_new
@@ -19,6 +19,36 @@ class PicturesControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :ok
     assert_select 'h1', 'Image Uploaded'
+    assert_select 'img', Picture.all.count
+  end
+
+  def test_index__filtered_by_existing_tag
+    get '/tagged?tag=existing_tag'
+
+    assert_response :ok
+    assert_select 'img', 1
+
+    Picture.create!(name: 'Alice_2',
+                    link: 'https://robohash.org/64M.png?set=set4',
+                    tag_list: 'cat, animal, existing_tag')
+
+    get '/tagged?tag=existing_tag'
+
+    assert_response :ok
+    assert_select 'img', 2
+  end
+
+  def test_index__filtered_by_non_existing_tag
+    get '/tagged?tag=no_such_tag'
+
+    assert_response :ok
+    assert_select 'img', 0
+  end
+
+  def test_index__filtered_by_empty_tag
+    get '/tagged?tag='
+
+    assert_response :ok
     assert_select 'img', Picture.all.count
   end
 


### PR DESCRIPTION
As a user I want to view all images associated with a tag.
**Story:**
Now that we have added the ability for images to be associated with tags, let
us provide the ability for users to filter images by a given tag. Nana, who
loves fast planes, will be delighted to see only images labeled with SR-71.

**Acceptance criteria:**

-   When I click on a tag, I see a filtered list of only the images that have the tag I clicked on.
-   The tag name, not its ID, is used to perform the filtering.

**Discussion topics:**
-   Where in the code should we implement this functionality?
-   What happens if a user tries to manually filter by a nonexistent tag?

Dependencies:
**Image Tags**